### PR TITLE
ci: remove gpg setup step (gpg already exist in ubuntu-20.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           java-version: openjdk@1.17.0
 
-      - name: Setup GPG
-        uses: olafurpg/setup-gpg@v3
-
       - name: Test
         run: sbt compile test
 


### PR DESCRIPTION
Remove gpg build from GitHub Actions, because gpg version from step is to old for ECDSA keys. In image ubuntu-20.04 gpg already installed. [ubuntu-20.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md)